### PR TITLE
Add deep_copy calls missing because of a Y2R bug

### DIFF
--- a/src/include/sound/manual.rb
+++ b/src/include/sound/manual.rb
@@ -267,7 +267,9 @@ module Yast
             next
           end
 
-          keys_names = keys == "vendors" ? vendor_names : module_names
+          keys_names = keys == "vendors" ?
+            deep_copy(vendor_names) :
+            deep_copy(module_names)
 
           UI.ChangeWidget(Id(:sel_keys), :Items, keys_names)
 

--- a/src/include/sound/volume.rb
+++ b/src/include/sound/volume.rb
@@ -278,7 +278,7 @@ module Yast
           Convert.convert(save_info, :from => "list", :to => "list <map>")
         ) do |card|
           pos = Ops.add(pos, 1)
-          pos == card_id ? save_entry : card
+          pos == card_id ? deep_copy(save_entry) : deep_copy(card)
         end
       end
 


### PR DESCRIPTION
See https://github.com/yast/y2r/issues/47.
