### PR TITLE
removed a FIXME note

### DIFF
--- a/src/include/sound/write_routines.rb
+++ b/src/include/sound/write_routines.rb
@@ -183,9 +183,6 @@ module Yast
     def RemovedUnusuedKernelModules
       # TODO: Needs deeper refactoring as knowledge of the data structure should
       #       not be needed.
-      #
-      # FIXME: Possible issue if the same module is used for another sound card
-      #        which stays configured and thus the module should be loaded.
       Sound.removed_info.reject{ |r| r.fetch("module", "").empty? }.each do |r|
         Kernel.RemoveModuleToLoad(r["module"])
       end


### PR DESCRIPTION
The issue is not valid, duplicate modules are handled properly.

`RemovedUnusuedKernelModules` is called before saving the config, if the module is used by another card it is added back again later.

Called from https://github.com/yast/yast-sound/blob/71dbc16fdfcb086e04841bf6c091f69554c02c8d/src/include/sound/write_routines.rb#L373, before https://github.com/yast/yast-sound/blob/71dbc16fdfcb086e04841bf6c091f69554c02c8d/src/include/sound/write_routines.rb#L408
as required in comment https://github.com/yast/yast-sound/blob/71dbc16fdfcb086e04841bf6c091f69554c02c8d/src/include/sound/write_routines.rb#L229
