### PR TITLE
Fix regexp to respect changed output of modprobe (bsc#972315) & Fixed dependency on yast2 version that contains .proc.modules agent (bsc#972310)

### DIFF
--- a/package/yast2-sound.changes
+++ b/package/yast2-sound.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar 23 16:47:36 UTC 2016 - cwh@suse.com
+
+- Fixed dependency on yast2 version that contains .proc.modules
+  agent (bsc#972310)
+
+-------------------------------------------------------------------
 Wed Oct  7 09:41:12 UTC 2015 - lslezak@suse.cz
 
 - do not check for %suse_version == 1315, the existing check for

--- a/package/yast2-sound.changes
+++ b/package/yast2-sound.changes
@@ -3,6 +3,8 @@ Wed Mar 23 16:47:36 UTC 2016 - cwh@suse.com
 
 - Fixed dependency on yast2 version that contains .proc.modules
   agent (bsc#972310)
+- Fixed regexp to respect changed output of modprobe (bsc#972315)
+- 3.1.9
 
 -------------------------------------------------------------------
 Wed Oct  7 09:41:12 UTC 2015 - lslezak@suse.cz

--- a/package/yast2-sound.spec
+++ b/package/yast2-sound.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sound
-Version:        3.1.8
+Version:        3.1.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-sound.spec
+++ b/package/yast2-sound.spec
@@ -44,7 +44,8 @@ BuildRequires:  yast2-testsuite
 
 # Fixed handling of Kernel modules loaded on boot
 Requires:       alsa
-Requires:       yast2 >= 3.1.3
+# For proc_modules.scr
+Requires:       yast2 >= 3.1.180
 
 Provides:       yast2-agent-audio
 Provides:       yast2-agent-audio-devel

--- a/src/bin/alsadrivers
+++ b/src/bin/alsadrivers
@@ -54,7 +54,7 @@ load_sequencer() {
 
 get_drivers() {
   /sbin/modprobe -c | \
-    grep -E "^[[:space:]]*alias[[:space:]]+snd-card-[[:digit:]]" | sort -u | \
+    grep -E "^[[:space:]]*alias[[:space:]]+snd[-_]card[-_][[:digit:]]" | sort -u | \
     while read a b card; do
 	echo $card
     done


### PR DESCRIPTION
Related PR: https://github.com/yast/yast-yast2/pull/453