### PR TITLE
Restore back a SLE workaround (disable on 32-bit archs)

### DIFF
--- a/package/yast2-sound.changes
+++ b/package/yast2-sound.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul  9 12:45:06 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Restore back a SLE workaround (disable on 32-bit archs)
+  (related to the previous fix fate#319035)
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:40:00 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-sound.spec
+++ b/package/yast2-sound.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sound
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Summary:        YaST2 - Sound Configuration
 License:        GPL-2.0-or-later
@@ -25,6 +25,12 @@ Group:          System/YaST
 Url:            https://github.com/yast/yast-sound
 
 Source0:        %{name}-%{version}.tar.bz2
+
+# FIXME: SLE-12/15 builds packages for x86 and s390 (both 32 bit),
+# but no runnable kernel, so this package cannot be built there.
+%if !0%{?is_opensuse}
+ExcludeArch:    %ix86 s390
+%endif
 
 BuildRequires:  alsa-devel
 BuildRequires:  doxygen


### PR DESCRIPTION
## The Problem

- IBS reports a build failure on i586.

## Details

- That `ExcludeArch` has been accidentally removed in #33, the comment only mentioned SLE-12, but in fact the same workaround is still needed in SLE-15
- Reverted back
- Added SLE15 comment (in SLE16 we will need to check again :grin: )
