### PR TITLE
Only record the first 2 numbers of kernel version

### DIFF
--- a/data/sound_db_generator.rb
+++ b/data/sound_db_generator.rb
@@ -144,7 +144,7 @@ class SoundCardDBGenerator
     card_addons = YAML.load_file "data_cards.yml"
     mixer = YAML.load_file "data_mixer.yml"
 
-    path.match /^\/lib\/modules\/([^\/]*)\//
+    path.match /^\/lib\/modules\/(\d+\.\d+)/
     kernel_ver = $1
 
     sound_card_db = {

--- a/package/yast2-sound.changes
+++ b/package/yast2-sound.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul  9 14:37:08 UTC 2020 - Bernhard Wiedemann <bwiedemann@suse.com>
+
+- Only record the first 2 numbers of kernel version (boo#1173918)
+- 4.3.2
+
+-------------------------------------------------------------------
 Tue May 12 15:42:51 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Autoyast schema: Allow optional types for string and map objects

--- a/package/yast2-sound.spec
+++ b/package/yast2-sound.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sound
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Summary:        YaST2 - Sound Configuration
 License:        GPL-2.0-or-later


### PR DESCRIPTION
Only record the first 2 numbers of kernel version
as it is the most significant for the output.
Maybe kernel is not needed at all.

Helps to make package build results less dependent on kernel version
https://bugzilla.suse.com/show_bug.cgi?id=1173918

See also https://reproducible-builds.org/ for why this matters.