### PR TITLE
Fix module filename matching (jsc#SLE-21256).

### DIFF
--- a/data/alsa_drivers.rb
+++ b/data/alsa_drivers.rb
@@ -122,11 +122,7 @@ class AlsaModule
 
   # find all sound drivers below the given path
   def self.find_all(path)
-    files = (Dir.glob(File.join(path, "**", "snd-*.ko"))
-             + Dir.glob(File.join(path, "**", "snd-*.ko.gz"))
-             + Dir.glob(File.join(path, "**", "snd-*.ko.xz"))
-             + Dir.glob(File.join(path, "**", "snd-*.ko.zst"))
-            ).select { |f| File.file?(f) }
+    files = Dir.glob(File.join(path, "**", "snd-*.ko{,.gz,.xz,.zst}")).select { |f| File.file?(f) }
 
     files.sort! { |f1, f2| File.basename(f1) <=> File.basename(f2) }
 

--- a/data/alsa_drivers.rb
+++ b/data/alsa_drivers.rb
@@ -73,7 +73,7 @@ class AlsaModule
 
   #  get just the module name from the driver path
   def name
-    @mod_path.match /\/([^\/]*).ko.xz$/
+    @mod_path.match /\/([^\/]*).ko(?:.(?:xz|gz|zst))?$/
     return $1
   end
 
@@ -122,7 +122,11 @@ class AlsaModule
 
   # find all sound drivers below the given path
   def self.find_all(path)
-    files = Dir.glob(File.join(path, "**", "snd-*.ko.xz")).select { |f| File.file?(f) }
+    files = (Dir.glob(File.join(path, "**", "snd-*.ko"))
+             + Dir.glob(File.join(path, "**", "snd-*.ko.gz"))
+             + Dir.glob(File.join(path, "**", "snd-*.ko.xz"))
+             + Dir.glob(File.join(path, "**", "snd-*.ko.zst"))
+            ).select { |f| File.file?(f) }
 
     files.sort! { |f1, f2| File.basename(f1) <=> File.basename(f2) }
 

--- a/package/yast2-sound.changes
+++ b/package/yast2-sound.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Feb  2 09:19:14 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Support uncompressed as well as xz, zstd, and gzip compressed
+  modules. Related to jsc#SLE-21256 - jsc#SLE-18768 entries
+  and sent by Michal Suchanek <msuchanek@suse.de>.
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0 (bsc#1185510)

--- a/package/yast2-sound.spec
+++ b/package/yast2-sound.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sound
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Summary:        YaST2 - Sound Configuration
 License:        GPL-2.0-or-later


### PR DESCRIPTION
Support uncompressed as well as xz, zstd, and gzip compressed modules.
